### PR TITLE
feat(opora): post-payment success and error pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,6 @@ PAGESPEED_API_KEY=PAGESPEED_API_KEY
 # Opora course checkout (external payment link)
 # ============================================
 PUBLIC_OPORA_CHECKOUT_URL=https://secure.wayforpay.com/button/b6a890feb5088
+
+# Telegram bot that delivers the Opora course after payment
+PUBLIC_OPORA_BOT_URL=https://t.me/your_bot

--- a/docs/superpowers/plans/2026-06-21-legal-pages.md
+++ b/docs/superpowers/plans/2026-06-21-legal-pages.md
@@ -1,0 +1,458 @@
+# Legal Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Ukrainian public-offer page and re-align the existing terms and privacy pages so the site's legal documents match its real business model (digital mini-courses via Telegram paid through WayForPay, plus coaching).
+
+**Architecture:** Three static Astro pages following the existing legal-page pattern (`BaseLayout` + `Header variant="main"` + `Footer variant="legal"`, Tailwind, `<article class="max-w-4xl mx-auto">`). A new `/oferta` page is created; `/terms` and `/privacy-policy` are edited in place. The footer legal block gains a third link. Playwright e2e tests cover the new page and cross-navigation.
+
+**Tech Stack:** Astro 4.x (SSG), Tailwind CSS 3.x, Playwright (e2e). No React, no new dependencies.
+
+## Global Constraints
+
+- All page content, headings, and copy: **Ukrainian**. Code, comments, commit messages: **English**.
+- Original Ukrainian copy only — **do not reproduce text from sviridov-pro.com or any example site**.
+- Seller is a Ukrainian **ФОП**; concrete requisites are unknown — use explicit placeholders (`[ПІБ]`, `[РНОКПП]`, `[дата]`) for the owner to fill in.
+- Contact email already used across the site: `hello@zhulova.com`.
+- Markup pattern for every section: `<h2 class="text-2xl font-serif text-navy-900 mb-4">` heading inside `<section class="mb-10">`, body in `<div class="text-navy-700 leading-relaxed space-y-4">`, lists as `<ul class="list-disc list-inside space-y-2 ml-4">`, internal links as `class="text-gold-600 hover:text-gold-400 underline transition-colors"`.
+- Refund policy is **mixed**: digital products — consent to immediate access + waiver of the 14-day withdrawal right, no refund after access granted; coaching — refund for sessions not delivered, 24h cancellation/reschedule rule.
+- Do NOT `git push`. Commit only.
+- Build must pass: `npm run build` runs `astro check` first and fails on type errors.
+
+---
+
+### Task 1: Public offer page `/oferta`
+
+**Files:**
+- Create: `src/pages/oferta.astro`
+- Test: `tests/e2e/legal-pages.spec.ts` (add an "Offer Page" describe block)
+
+**Interfaces:**
+- Consumes: `@layouts/BaseLayout.astro`, `@components/layout/Header.astro`, `@components/layout/Footer.astro` (existing, unchanged).
+- Produces: a page reachable at route `/oferta` with `<main>` containing a single `<h1>` "Публічна оферта" and BaseLayout `<title>` matching `/публічна оферта/i`. Task 4's footer link and cross-nav test depend on this route and title.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Append this describe block inside the top-level `test.describe('Legal Pages', () => { ... })` in `tests/e2e/legal-pages.spec.ts`, after the `Terms Page` block (around line 177, before `Cross-page navigation`):
+
+```typescript
+  test.describe('Offer Page', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/oferta', { waitUntil: 'networkidle' });
+    });
+
+    test('should load offer page successfully', async ({ page }) => {
+      await expect(page).toHaveURL(/oferta/);
+      await expect(page).toHaveTitle(/публічна оферта/i);
+    });
+
+    test('should display offer heading', async ({ page }) => {
+      const heading = page.locator('main h1').first();
+      await expect(heading).toBeVisible();
+      await expect(heading).toContainText(/публічна оферта/i);
+    });
+
+    test('should have seller requisites section', async ({ page }) => {
+      const main = page.locator('main');
+      await expect(main).toContainText(/реквізити продавця/i);
+    });
+
+    test('should link to privacy policy', async ({ page }) => {
+      const privacyLink = page.locator('main a[href="/privacy-policy"]').first();
+      await expect(privacyLink).toBeVisible();
+    });
+
+    test('should have proper meta tags for SEO', async ({ page }) => {
+      const metaDescription = page.locator('meta[name="description"]');
+      await expect(metaDescription).toHaveAttribute('content', /.+/);
+      const ogTitle = page.locator('meta[property="og:title"]');
+      await expect(ogTitle).toHaveAttribute('content', /.+/);
+    });
+
+    test('should have footer', async ({ page }) => {
+      const footer = page.getByRole('contentinfo');
+      await expect(footer).toBeVisible();
+      await expect(footer).toContainText(/© \d{4}/);
+    });
+
+    test('should work on mobile viewport', async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      const heading = page.locator('main h1').first();
+      await expect(heading).toBeVisible();
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx playwright test --project=chromium tests/e2e/legal-pages.spec.ts -g "Offer Page"`
+Expected: FAIL — page `/oferta` returns 404, title/heading assertions fail.
+
+- [ ] **Step 3: Create the offer page**
+
+Create `src/pages/oferta.astro`. Use the structure below. Headings are fixed (exact Ukrainian text required); for descriptive paragraphs, write original Ukrainian prose following the Global Constraints markup pattern. The legally-critical clauses (sections 7 and 15) are given verbatim — use them as written.
+
+```astro
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Header from '@components/layout/Header.astro';
+import Footer from '@components/layout/Footer.astro';
+---
+
+<BaseLayout
+  title="Публічна оферта - Вікторія Жульова"
+  description="Договір публічної оферти про надання цифрових продуктів та коучингових послуг. Умови оплати, доступу та повернення коштів."
+>
+  <Header variant="main" />
+
+  <main class="min-h-screen bg-white pt-32 pb-20 px-6">
+    <article class="max-w-4xl mx-auto">
+      <h1 class="text-4xl md:text-5xl font-serif text-navy-900 mb-8">
+        Публічна оферта
+      </h1>
+
+      <p class="text-sm text-navy-600 mb-8">Дата набрання чинності: [дата]</p>
+
+      <div class="mb-12 text-lg text-navy-700 leading-relaxed space-y-4">
+        <p>
+          Цей документ є офіційною публічною пропозицією (офертою) фізичної особи-підприємця
+          [ПІБ] (далі — «Виконавець») укласти договір про надання цифрових продуктів та
+          коучингових послуг на викладених нижче умовах.
+        </p>
+        <p>
+          Оплата замовлення означає повну та беззастережну згоду Замовника з умовами цієї оферти
+          (акцепт).
+        </p>
+      </div>
+
+      <!-- 1 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Загальні положення</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- offer is a public contract; acceptance occurs through payment; parties are Виконавець and Замовник -->
+        </div>
+      </section>
+
+      <!-- 2 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Терміни та визначення</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- define: Оферта, Акцепт, Виконавець, Замовник, Цифровий продукт, Коучингова послуга, Сайт -->
+        </div>
+      </section>
+
+      <!-- 3 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Предмет договору</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- Виконавець надає цифрові продукти та/або коучингові послуги; Замовник оплачує -->
+        </div>
+      </section>
+
+      <!-- 4 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Опис продуктів і послуг</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- digital: міні-курси та матеріали з доступом у Telegram; coaching: індивідуальні/групові онлайн-сесії -->
+        </div>
+      </section>
+
+      <!-- 5 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Вартість та порядок оплати</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- ціни вказані на сторінках продуктів; оплата через платіжний сервіс WayForPay; валюти UAH/EUR; разовий платіж; Виконавець не зберігає дані платіжних карток -->
+        </div>
+      </section>
+
+      <!-- 6 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Надання доступу та «доставка»</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- digital: доступ надається у Telegram одразу/невдовзі після оплати; coaching: час сесій узгоджується індивідуально -->
+        </div>
+      </section>
+
+      <!-- 7 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Повернення коштів</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p><strong>Цифрові продукти.</strong> Оплачуючи цифровий продукт, Замовник дає згоду на негайне надання доступу до контенту та підтверджує, що ознайомлений із втратою права на відмову протягом 14 днів після початку надання доступу. Після надання доступу до цифрового продукту кошти поверненню не підлягають.</p>
+          <p><strong>Коучингові послуги.</strong> Замовник має право відмовитися від подальших послуг; у такому разі повертаються кошти за непроведені (ненадані) сесії. Перенесення або скасування сесії можливе за умови попередження не менше ніж за 24 години — інакше сесія вважається проведеною.</p>
+          <p><strong>Винятки.</strong> Якщо послуга не була надана з вини Виконавця, кошти повертаються у повному обсязі протягом 7 робочих днів.</p>
+        </div>
+      </section>
+
+      <!-- 8 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Права та обов'язки сторін</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- обов'язки Виконавця (надати доступ/послугу) та Замовника (оплатити, не порушувати правила, не передавати доступ третім особам) -->
+        </div>
+      </section>
+
+      <!-- 9 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Інтелектуальна власність</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- усі матеріали — власність Виконавця; заборона копіювання, поширення, комерційного використання без письмової згоди -->
+        </div>
+      </section>
+
+      <!-- 10 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Відповідальність та обмеження</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- коучинг не є психотерапією/медичною послугою; Виконавець не гарантує конкретних результатів; результат залежить від зусиль Замовника -->
+        </div>
+      </section>
+
+      <!-- 11 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Форс-мажор</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- обставини непереборної сили (війна, стихійні лиха, відключення зв'язку) звільняють від відповідальності; послуги переносяться -->
+        </div>
+      </section>
+
+      <!-- 12 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Конфіденційність</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p>Обробка персональних даних здійснюється відповідно до <a href="/privacy-policy" class="text-gold-600 hover:text-gold-400 underline transition-colors">Політики конфіденційності</a>.</p>
+        </div>
+      </section>
+
+      <!-- 13 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Строк дії та зміна умов</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- оферта діє безстроково до відкликання; Виконавець може змінювати умови, актуальна редакція — на Сайті -->
+        </div>
+      </section>
+
+      <!-- 14 --> <section class="mb-10"><h2 class="text-2xl font-serif text-navy-900 mb-4">Вирішення спорів</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- регулюється законодавством України; спори — у досудовому порядку, інакше у судах України; згадати захист прав споживачів -->
+        </div>
+      </section>
+
+      <!-- 15 --> <section class="mb-10 p-6 bg-sage-50 rounded-lg"><h2 class="text-2xl font-serif text-navy-900 mb-4">Реквізити продавця</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p>
+            <strong>Фізична особа-підприємець:</strong> [ПІБ]<br />
+            <strong>РНОКПП / ЄДРПОУ:</strong> [РНОКПП]<br />
+            <strong>Email:</strong> <a href="mailto:hello@zhulova.com" class="text-gold-600 hover:text-gold-400 underline transition-colors">hello@zhulova.com</a><br />
+            <strong>Веб-сайт:</strong> <a href="https://zhulova.com" class="text-gold-600 hover:text-gold-400 underline transition-colors">zhulova.com</a>
+          </p>
+        </div>
+      </section>
+
+    </article>
+  </main>
+
+  <Footer variant="legal" />
+</BaseLayout>
+```
+
+- [ ] **Step 4: Run the offer e2e tests to verify they pass**
+
+Run: `npx playwright test --project=chromium tests/e2e/legal-pages.spec.ts -g "Offer Page"`
+Expected: PASS (all 7 tests in the Offer Page block).
+
+- [ ] **Step 5: Verify the build passes**
+
+Run: `npm run build`
+Expected: `astro check` reports 0 errors; build completes and emits `dist/oferta/index.html`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/oferta.astro tests/e2e/legal-pages.spec.ts
+git commit -m "feat(legal): add public offer page (/oferta)"
+```
+
+---
+
+### Task 2: Slim down `/terms`
+
+**Files:**
+- Modify: `src/pages/terms.astro` (currently ~237 lines, replace body sections)
+
+**Interfaces:**
+- Consumes: existing `/oferta` route (Task 1) and `/privacy-policy` route for internal links.
+- Produces: a lighter terms page; title still matches `/умови використання/i` (existing e2e in `Terms Page` block relies on this — do not change the title or `<h1>`).
+
+- [ ] **Step 1: Replace the page body with the slimmed structure**
+
+Keep the frontmatter, `<BaseLayout>` wrapper, `title`, `Header`, `<main>`, `<h1>Умови використання</h1>`, and `<Footer variant="legal" />` exactly as they are. Replace everything between the `<h1>` and the closing `</article>` with these sections (write original Ukrainian prose following the markup pattern):
+
+```astro
+      <div class="mb-12 text-lg text-navy-700 leading-relaxed space-y-4">
+        <p>
+          Ці Умови використання регулюють користування веб-сайтом zhulova.com. Користуючись
+          сайтом, ви погоджуєтеся з цими умовами.
+        </p>
+      </div>
+
+      <section class="mb-10">
+        <h2 class="text-2xl font-serif text-navy-900 mb-4">Користування сайтом</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- загальні правила: сайт надається «як є»; заборона неправомірного використання; інформаційний характер контенту -->
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-2xl font-serif text-navy-900 mb-4">Покупки та оплата</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p>
+            Придбання цифрових продуктів та коучингових послуг регулюється
+            <a href="/oferta" class="text-gold-600 hover:text-gold-400 underline transition-colors">Публічною офертою</a>,
+            яка містить умови оплати, надання доступу та повернення коштів.
+          </p>
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-2xl font-serif text-navy-900 mb-4">Характер коучингу</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p><strong>Коучинг не є психотерапією або медичною послугою.</strong></p>
+          <!-- працюємо зі здоровими людьми; коучинг не замінює медичну/психологічну допомогу; за наявності медичних станів — звернутися до фахівця -->
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-2xl font-serif text-navy-900 mb-4">Інтелектуальна власність</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <!-- весь контент сайту (тексти, зображення, дизайн) належить Виконавцю; заборона копіювання без згоди -->
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-2xl font-serif text-navy-900 mb-4">Персональні дані</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p>
+            Обробка персональних даних описана в
+            <a href="/privacy-policy" class="text-gold-600 hover:text-gold-400 underline transition-colors">Політиці конфіденційності</a>.
+          </p>
+        </div>
+      </section>
+
+      <section class="mb-10 p-6 bg-sage-50 rounded-lg">
+        <h2 class="text-2xl font-serif text-navy-900 mb-4">Контакти</h2>
+        <div class="text-navy-700 leading-relaxed space-y-4">
+          <p>
+            <strong>Email:</strong> <a href="mailto:hello@zhulova.com" class="text-gold-600 hover:text-gold-400 underline transition-colors">hello@zhulova.com</a><br />
+            <strong>Веб-сайт:</strong> <a href="https://zhulova.com" class="text-gold-600 hover:text-gold-400 underline transition-colors">zhulova.com</a>
+          </p>
+        </div>
+      </section>
+```
+
+- [ ] **Step 2: Verify existing Terms e2e tests still pass**
+
+Run: `npx playwright test --project=chromium tests/e2e/legal-pages.spec.ts -g "Terms Page"`
+Expected: PASS (title and heading still `умови використання`; footer and nav unchanged).
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/terms.astro
+git commit -m "refactor(legal): slim terms page; move purchase rules to offer"
+```
+
+---
+
+### Task 3: Refresh `/privacy-policy` data processors
+
+**Files:**
+- Modify: `src/pages/privacy-policy.astro:89-92` (the third-party services list inside "Хто має доступ до ваших даних")
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: privacy page reflecting the real stack; title unchanged (existing `Privacy Policy Page` e2e relies on `/політика конфіденційності/i`).
+
+- [ ] **Step 1: Expand the third-party processors list**
+
+Replace the `<ul>` at `src/pages/privacy-policy.astro:89-92`:
+
+```astro
+          <ul class="list-disc list-inside space-y-2 ml-4">
+            <li><strong>Supabase</strong> — постачальник хмарних баз даних для зберігання запитів на консультацію (GDPR-сумісний)</li>
+            <li><strong>Resend</strong> — сервіс електронної пошти для надсилання сповіщень про нові запити (GDPR-сумісний)</li>
+          </ul>
+```
+
+with:
+
+```astro
+          <ul class="list-disc list-inside space-y-2 ml-4">
+            <li><strong>Supabase</strong> — постачальник хмарних баз даних для зберігання запитів на консультацію (GDPR-сумісний)</li>
+            <li><strong>Resend</strong> — сервіс електронної пошти для надсилання сповіщень про нові запити (GDPR-сумісний)</li>
+            <li><strong>WayForPay</strong> — платіжний сервіс для обробки онлайн-оплат; дані платіжних карток обробляються на стороні сервісу і не зберігаються нами</li>
+            <li><strong>Vercel</strong> — хостинг сайту та аналітика продуктивності (Analytics, Speed Insights)</li>
+            <li><strong>Telegram</strong> — канал надання доступу до придбаних цифрових продуктів</li>
+          </ul>
+```
+
+- [ ] **Step 2: Verify existing Privacy e2e tests still pass**
+
+Run: `npx playwright test --project=chromium tests/e2e/legal-pages.spec.ts -g "Privacy Policy Page"`
+Expected: PASS.
+
+- [ ] **Step 3: Verify the build passes**
+
+Run: `npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/privacy-policy.astro
+git commit -m "docs(legal): align privacy policy with WayForPay/Vercel/Telegram processors"
+```
+
+---
+
+### Task 4: Footer link to the offer + cross-navigation test
+
+**Files:**
+- Modify: `src/components/layout/Footer.astro:190-205` (legal links nav)
+- Test: `tests/e2e/legal-pages.spec.ts` (extend the `Cross-page navigation` describe block)
+
+**Interfaces:**
+- Consumes: `/oferta` route (Task 1).
+- Produces: footer legal block links to all three legal pages on every page that renders the footer.
+
+- [ ] **Step 1: Add the offer link to the footer legal nav**
+
+In `src/components/layout/Footer.astro`, inside the `<nav aria-label="Legal navigation">` block (~line 190), add a third link after the existing «Умови використання» link (after line 204):
+
+```astro
+            <a
+              href="/oferta"
+              class="text-sm text-navy-300 hover:text-gold-400 transition-colors"
+              aria-label="Перейти до публічної оферти"
+            >
+              Публічна оферта
+            </a>
+```
+
+- [ ] **Step 2: Add a cross-navigation assertion for the offer link**
+
+In `tests/e2e/legal-pages.spec.ts`, inside `test.describe('Cross-page navigation', ...)`, add this test after the existing `should navigate between privacy and terms pages` test:
+
+```typescript
+    test('should link to offer from footer on legal pages', async ({ page }) => {
+      await page.goto('/terms', { waitUntil: 'networkidle' });
+      const offerLink = page.getByRole('contentinfo').locator('a[href="/oferta"]').first();
+      await expect(offerLink).toBeVisible();
+      await offerLink.click();
+      await expect(page).toHaveURL(/oferta/);
+    });
+```
+
+- [ ] **Step 3: Run the full legal-pages e2e suite**
+
+Run: `npx playwright test --project=chromium tests/e2e/legal-pages.spec.ts`
+Expected: PASS (all Privacy, Terms, Offer, and Cross-page navigation tests).
+
+- [ ] **Step 4: Verify the build passes**
+
+Run: `npm run build`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/layout/Footer.astro tests/e2e/legal-pages.spec.ts
+git commit -m "feat(legal): add public offer link to footer legal nav"
+```
+
+---
+
+## Final verification
+
+- [ ] Run full unit + e2e legal coverage: `npm run test:run` and `npx playwright test --project=chromium tests/e2e/legal-pages.spec.ts` — all pass.
+- [ ] `npm run build` — 0 type errors; `dist/oferta/index.html`, `dist/terms/index.html`, `dist/privacy-policy/index.html` all emitted.
+- [ ] Manually confirm `/oferta`, `/terms`, `/privacy-policy` render in Ukrainian, share header/footer, and the footer shows all three legal links.
+- [ ] Confirm requisite placeholders (`[ПІБ]`, `[РНОКПП]`, `[дата]`) remain visible for the owner to fill in.

--- a/docs/superpowers/plans/2026-06-21-opora-payment-result-pages.md
+++ b/docs/superpowers/plans/2026-06-21-opora-payment-result-pages.md
@@ -1,0 +1,404 @@
+# Opora Payment Result Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add branded success and error pages that WayForPay redirects to after a payment for the "Опора на себе" course, routing buyers to the Telegram bot.
+
+**Architecture:** Two static Astro pages nested under `/courses/opora/`, built with the existing `BaseLayout` + `Header` + `Footer` and the existing `CtaButton`. A new optional `noindex` prop on `BaseLayout` keeps these pages out of search. The bot link comes from a new `PUBLIC_OPORA_BOT_URL` env var (falls back to `/contacts` when unset). No serverless code — the pages are informational only.
+
+**Tech Stack:** Astro 4 (SSG), Tailwind CSS 3, Playwright (e2e). Spec: `docs/superpowers/specs/2026-06-21-opora-payment-result-pages-design.md`.
+
+## Global Constraints
+
+- UI copy is **Ukrainian**; all code, comments, and commit messages are **English**.
+- Pages are **static** (Astro `output: 'static'`); no server-side rendering, no payment verification.
+- Reuse `@components/sections/opora/CtaButton.astro` for buttons (it already opens `http*` links in a new tab with `rel="noopener noreferrer"`).
+- Reuse `BaseLayout` (`@layouts/BaseLayout.astro`), `Header` (`@components/layout/Header.astro`, `variant="main"`), `Footer` (`@components/layout/Footer.astro`, `variant="legal"`) — same as `src/pages/courses/opora.astro`.
+- `PUBLIC_*` display links may use a non-secret fallback (this is not a secret-bearing API var, so the "no fallback" rule for API secrets does not apply here).
+- Run e2e with: `npx playwright test <file> --project=chromium`.
+
+---
+
+### Task 1: Success page (`/courses/opora/success`) + `noindex` support
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro` (add optional `noindex` prop + robots meta)
+- Modify: `.env.example` (document `PUBLIC_OPORA_BOT_URL`)
+- Modify: `.env` (local value; gitignored, not committed)
+- Create: `src/pages/courses/opora/success.astro`
+- Test: `tests/e2e/opora-payment-pages.spec.ts`
+
+**Interfaces:**
+- Consumes: `BaseLayout` with new `noindex?: boolean` prop; `CtaButton` (`href: string` prop, external links open in new tab).
+- Produces: route `/courses/opora/success`; env var `PUBLIC_OPORA_BOT_URL`; `BaseLayout` `noindex` prop reused by Task 2.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Create `tests/e2e/opora-payment-pages.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the Opora payment result pages (success / error).
+ * These pages are where WayForPay redirects the buyer after payment.
+ */
+
+test.describe('Opora Payment Result Pages', () => {
+  test.describe('Success page (/courses/opora/success)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/courses/opora/success', { waitUntil: 'networkidle' });
+    });
+
+    test('should load successfully', async ({ page }) => {
+      await expect(page).toHaveURL(/\/courses\/opora\/success$/);
+    });
+
+    test('should display a heading', async ({ page }) => {
+      const heading = page.locator('main h1').first();
+      await expect(heading).toBeVisible();
+      await expect(heading).toContainText(/успішно/i);
+    });
+
+    test('should have a primary CTA with a non-empty link', async ({ page }) => {
+      const cta = page.locator('main a').filter({ hasText: /забрати курс/i }).first();
+      await expect(cta).toBeVisible();
+      const href = await cta.getAttribute('href');
+      expect(href).toBeTruthy();
+      expect(href!.length).toBeGreaterThan(1);
+    });
+
+    test('should be excluded from search engines (noindex)', async ({ page }) => {
+      const robots = page.locator('meta[name="robots"]');
+      await expect(robots).toHaveAttribute('content', /noindex/);
+    });
+
+    test('should have navigation and footer', async ({ page }) => {
+      await expect(page.getByRole('banner')).toBeVisible();
+      await expect(page.getByRole('contentinfo')).toBeVisible();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx playwright test tests/e2e/opora-payment-pages.spec.ts --project=chromium`
+Expected: FAIL — the page 404s (no `main h1` / wrong URL), `meta[name="robots"]` not found.
+
+- [ ] **Step 3: Add `noindex` support to `BaseLayout`**
+
+In `src/layouts/BaseLayout.astro`, change the `Props` interface (lines 6–11):
+
+```astro
+interface Props {
+  title: string;
+  description: string;
+  image?: string;
+  canonical?: string;
+  noindex?: boolean;
+}
+```
+
+Change the props destructuring (lines 13–18):
+
+```astro
+const {
+  title,
+  description,
+  image = '/images/og-default.jpg',
+  canonical,
+  noindex = false,
+} = Astro.props;
+```
+
+Add the robots meta right after the description meta (after line 35, `<meta name="description" ... />`):
+
+```astro
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
+```
+
+- [ ] **Step 4: Add the bot env var to `.env.example` and `.env`**
+
+In `.env.example`, append after the `PUBLIC_OPORA_CHECKOUT_URL` line:
+
+```bash
+# Telegram bot that delivers the Opora course after payment
+PUBLIC_OPORA_BOT_URL=https://t.me/your_bot
+```
+
+In `.env` (local, gitignored), add the same key (leave the value empty for now — the page will fall back to `/contacts`):
+
+```bash
+PUBLIC_OPORA_BOT_URL=
+```
+
+- [ ] **Step 5: Create the success page**
+
+Create `src/pages/courses/opora/success.astro`:
+
+```astro
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Header from '@components/layout/Header.astro';
+import Footer from '@components/layout/Footer.astro';
+import CtaButton from '@components/sections/opora/CtaButton.astro';
+
+// Bot link delivers the course; fall back to contacts if not configured yet.
+const botUrl: string = import.meta.env.PUBLIC_OPORA_BOT_URL || '/contacts';
+---
+
+<BaseLayout
+  title="Оплата успішна — Опора на себе · Вікторія Жульова"
+  description="Оплата пройшла успішно. Відкрий телеграм-бот, щоб забрати курс «Опора на себе»."
+  noindex
+>
+  <Header variant="main" />
+
+  <main class="min-h-screen bg-white pt-32 pb-20">
+    <section class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <div
+        class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gold-100 text-gold-600"
+      >
+        <svg
+          class="h-8 w-8"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+
+      <h1 class="text-3xl md:text-4xl font-serif font-bold text-navy-900 mb-4">
+        Оплата пройшла успішно
+      </h1>
+
+      <p class="text-lg text-navy-700 mb-8 leading-relaxed">
+        Дякую за покупку! Доступ до курсу — у телеграм-боті. Натисни кнопку нижче, щоб
+        відкрити його й почати.
+      </p>
+
+      <CtaButton href={botUrl}>Відкрити бота й забрати курс</CtaButton>
+
+      <p class="mt-6 text-sm text-navy-500">
+        Бот не відкрився?
+        <a href="/contacts" class="text-gold-600 underline hover:text-gold-500">Напиши нам</a>.
+      </p>
+    </section>
+  </main>
+
+  <Footer variant="legal" />
+</BaseLayout>
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx playwright test tests/e2e/opora-payment-pages.spec.ts --project=chromium`
+Expected: PASS (all success-page tests green).
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro .env.example src/pages/courses/opora/success.astro tests/e2e/opora-payment-pages.spec.ts
+git commit -m "feat(opora): add post-payment success page and BaseLayout noindex"
+```
+
+---
+
+### Task 2: Error page (`/courses/opora/error`)
+
+**Files:**
+- Create: `src/pages/courses/opora/error.astro`
+- Test: `tests/e2e/opora-payment-pages.spec.ts` (extend with an error-page describe block)
+
+**Interfaces:**
+- Consumes: `BaseLayout` `noindex` prop (from Task 1); `CtaButton`; env var `PUBLIC_OPORA_CHECKOUT_URL` (already used by `src/pages/courses/opora.astro`).
+- Produces: route `/courses/opora/error`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Append this describe block inside the top-level `test.describe('Opora Payment Result Pages', ...)` in `tests/e2e/opora-payment-pages.spec.ts`, right after the Success page block:
+
+```typescript
+  test.describe('Error page (/courses/opora/error)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/courses/opora/error', { waitUntil: 'networkidle' });
+    });
+
+    test('should load successfully', async ({ page }) => {
+      await expect(page).toHaveURL(/\/courses\/opora\/error$/);
+    });
+
+    test('should display a heading', async ({ page }) => {
+      const heading = page.locator('main h1').first();
+      await expect(heading).toBeVisible();
+      await expect(heading).toContainText(/не пройшла/i);
+    });
+
+    test('should have a retry CTA with a non-empty link', async ({ page }) => {
+      const cta = page.locator('main a').filter({ hasText: /спробувати ще раз/i }).first();
+      await expect(cta).toBeVisible();
+      const href = await cta.getAttribute('href');
+      expect(href).toBeTruthy();
+    });
+
+    test('should link to contacts', async ({ page }) => {
+      await expect(page.locator('main a[href="/contacts"]').first()).toBeVisible();
+    });
+
+    test('should be excluded from search engines (noindex)', async ({ page }) => {
+      const robots = page.locator('meta[name="robots"]');
+      await expect(robots).toHaveAttribute('content', /noindex/);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx playwright test tests/e2e/opora-payment-pages.spec.ts --project=chromium`
+Expected: FAIL — error page 404s (no `main h1`, wrong URL, no robots meta). Success-page tests still pass.
+
+- [ ] **Step 3: Create the error page**
+
+Create `src/pages/courses/opora/error.astro`:
+
+```astro
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Header from '@components/layout/Header.astro';
+import Footer from '@components/layout/Footer.astro';
+import CtaButton from '@components/sections/opora/CtaButton.astro';
+
+// Send the buyer back to the WayForPay button to try again.
+const checkoutUrl: string = import.meta.env.PUBLIC_OPORA_CHECKOUT_URL || '#';
+---
+
+<BaseLayout
+  title="Оплата не пройшла — Опора на себе · Вікторія Жульова"
+  description="Оплата не пройшла. Спробуй ще раз або звернись до нас."
+  noindex
+>
+  <Header variant="main" />
+
+  <main class="min-h-screen bg-white pt-32 pb-20">
+    <section class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h1 class="text-3xl md:text-4xl font-serif font-bold text-navy-900 mb-4">
+        Оплата не пройшла
+      </h1>
+
+      <p class="text-lg text-navy-700 mb-8 leading-relaxed">
+        Щось пішло не так під час оплати, і гроші не списано. Спробуй ще раз — це займе
+        хвилину.
+      </p>
+
+      <CtaButton href={checkoutUrl}>Спробувати ще раз</CtaButton>
+
+      <p class="mt-6 text-sm text-navy-500">
+        Не виходить?
+        <a href="/contacts" class="text-gold-600 underline hover:text-gold-500">Звернись до нас</a>.
+      </p>
+    </section>
+  </main>
+
+  <Footer variant="legal" />
+</BaseLayout>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx playwright test tests/e2e/opora-payment-pages.spec.ts --project=chromium`
+Expected: PASS (both success and error page blocks green).
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/courses/opora/error.astro tests/e2e/opora-payment-pages.spec.ts
+git commit -m "feat(opora): add post-payment error page"
+```
+
+---
+
+### Task 3: Deploy config — Vercel env var + WayForPay cabinet
+
+**Files:** none (operational configuration).
+
+**Interfaces:**
+- Consumes: routes `/courses/opora/success` and `/courses/opora/error` (Tasks 1–2); env var `PUBLIC_OPORA_BOT_URL`.
+- Produces: live, working redirect flow on production.
+
+- [ ] **Step 1: Add the bot URL to Vercel (Production + Preview)**
+
+Replace `<BOT_URL>` with the real Telegram bot link (e.g. `https://t.me/opora_bot`):
+
+```bash
+printf "<BOT_URL>" | vercel env add PUBLIC_OPORA_BOT_URL production
+printf "<BOT_URL>" | vercel env add PUBLIC_OPORA_BOT_URL preview
+```
+
+Verify:
+
+```bash
+vercel env ls | grep -i OPORA_BOT
+```
+
+Expected: `PUBLIC_OPORA_BOT_URL` listed for Production and Preview.
+
+- [ ] **Step 2: Configure the WayForPay button redirects (merchant cabinet)**
+
+In the WayForPay cabinet, open the payment button used for Opora, then:
+
+1. Enable the toggle **"Налаштувати переадресацію клієнта"**.
+2. **Approve URL:** `https://zhulova.com/courses/opora/success`
+3. **Decline URL:** `https://zhulova.com/courses/opora/error`
+4. Enable **"Вимкнути надсилання POST на returnUrl"** (forces a plain GET redirect so the static pages load correctly).
+5. Save.
+
+- [ ] **Step 3: Push to trigger a production deploy**
+
+```bash
+git push origin master
+```
+
+(Only after explicit approval to push — per project rules.)
+
+- [ ] **Step 4: Verify the live flow**
+
+After the deploy is `Ready`:
+
+```bash
+curl -s https://zhulova.com/courses/opora/success | grep -o 'noindex'
+curl -s https://zhulova.com/courses/opora/error | grep -o 'noindex'
+```
+
+Expected: `noindex` printed for both (pages are live and excluded from search). Then make a real test payment (or use WayForPay test mode) and confirm the redirect lands on `/courses/opora/success`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Success page → Task 1 ✓
+- Error page → Task 2 ✓
+- `PUBLIC_OPORA_BOT_URL` env var + `/contacts` fallback → Task 1 (Steps 4–5) ✓
+- `noindex` on both pages → Task 1 (BaseLayout prop) + used in both pages ✓
+- WayForPay cabinet config + POST→GET toggle → Task 3 ✓
+- Nested routing under `/courses/opora/` → Tasks 1–2 file paths ✓
+- E2E coverage (load, h1, CTA, noindex) → Tasks 1–2 ✓
+- Out of scope (payment verification, webhook, generic success page) → not implemented ✓
+
+**Placeholder scan:** No TBD/TODO. `<BOT_URL>` in Task 3 is an intentional operator-supplied value, clearly marked. Page copy is final Ukrainian text.
+
+**Type consistency:** `noindex?: boolean` defined in Task 1 BaseLayout `Props`, used as `noindex` attribute in both pages. `CtaButton` `href: string` matches existing component. `botUrl` / `checkoutUrl` are local `string` consts. CTA selectors in tests (`забрати курс`, `спробувати ще раз`) match the button label text in the pages.

--- a/docs/superpowers/specs/2026-06-21-legal-pages-design.md
+++ b/docs/superpowers/specs/2026-06-21-legal-pages-design.md
@@ -1,0 +1,127 @@
+# Legal Pages — Design
+
+**Date:** 2026-06-21
+**Status:** Approved (pending user spec review)
+**Topic:** T&C / Legal pages for zhulova.com (public offer, privacy, terms)
+
+## Problem
+
+The site currently ships two legal pages — `terms.astro` and `privacy-policy.astro` —
+both written in Ukrainian for a **1-on-1 coaching** business model (Zoom sessions,
+60–90 min, 24h reschedule rules, payment per session). The actual product now sold is a
+**digital mini-course** ("Опора на себе", €9, delivered via Telegram, one-time WayForPay
+payment). The legal documents are out of sync with what is actually being sold, and there
+is no public offer (договір публічної оферти) — which WayForPay acquiring expects for a
+merchant selling digital goods in Ukraine.
+
+## Decisions (from brainstorming)
+
+- **Business model covered:** both digital products (mini-courses via Telegram) **and**
+  coaching (individual/group sessions).
+- **Seller:** ФОП (Ukraine). Requisites unknown at authoring time → use explicit
+  placeholders for the owner to fill in (e.g. `[ПІБ]`, `[РНОКПП]`).
+- **Language:** Ukrainian, matching the rest of the site.
+- **Page set:** 3 pages (public offer + privacy + general site terms).
+- **Refund policy:** mixed —
+  - Digital products: buyer consents to immediate access and waives the 14-day
+    withdrawal right; after access is granted, no refund.
+  - Coaching: refund for sessions not yet delivered; cancellation/reschedule rules apply.
+- **Text source:** original Ukrainian copy written for this business model. The
+  sviridov-pro.com examples are used only as structural reference — **their text is not
+  copied**.
+
+## Pages
+
+### 1. `/oferta` — Публічна оферта (Договір) — NEW (`src/pages/oferta.astro`)
+
+A legally binding offer contract (acceptance = payment). This is the document WayForPay
+acquiring expects. Sections (Ukrainian headings):
+
+1. Загальні положення — offer accepted by payment.
+2. Терміни та визначення.
+3. Предмет договору — digital products + coaching.
+4. Опис продуктів і послуг — mini-courses delivered in Telegram; individual/group coaching.
+5. Вартість та порядок оплати — WayForPay, UAH/EUR, one-time payment.
+6. Надання доступу / «доставка» — Telegram access immediately after payment; coaching by
+   arrangement.
+7. Повернення коштів (mixed policy):
+   - Digital: consent to immediate access + waiver of the 14-day right; no refund once
+     access is granted.
+   - Coaching: refund for sessions not delivered; cancellation/reschedule rules (24h).
+8. Права та обов'язки сторін.
+9. Інтелектуальна власність.
+10. Відповідальність та обмеження — coaching is not therapy/medical care; no guaranteed
+    result.
+11. Форс-мажор.
+12. Конфіденційність — link to `/privacy-policy`.
+13. Строк дії, зміна умов.
+14. Вирішення спорів — Ukrainian law, consumer protection authority.
+15. Реквізити продавця — ФОП ПІБ, РНОКПП/ЄДРПОУ, email (placeholders).
+
+Add an effective-date / last-updated line.
+
+### 2. `/privacy-policy` — Політика конфіденційності — REFRESH existing
+
+Align with the real stack. Add/clarify data processors and channels:
+
+- **WayForPay** — payment processing; card data is not stored by us.
+- **Supabase** — storage of lead/contact submissions.
+- **Resend** — transactional email notifications.
+- **Vercel Analytics / Speed Insights** — usage and performance metrics.
+- **Telegram** — delivery channel for digital products.
+
+Keep a basic **cookies** section (no separate cookie page). Cover data subject rights,
+retention periods, and contact details. Preserve the existing structure and tone; update
+content to match the actual data flows.
+
+### 3. `/terms` — Умови використання — REFRESH existing
+
+Currently this file duplicates the role of an offer (payment, refunds, session rules).
+Slim it down to:
+
+- General rules of using the website.
+- Coaching disclaimer (not therapy / not medical care).
+- Intellectual property of site content.
+- A pointer: purchases are governed by the **Публічна оферта** (`/oferta`); personal data
+  by the **Політика конфіденційності** (`/privacy-policy`).
+
+Move all purchase/payment/refund/session detail out of this page into the offer.
+
+## Navigation
+
+In `src/components/layout/Footer.astro` (the legal links block, ~lines 190–205), add a
+third link **«Публічна оферта»** → `/oferta`, alongside the existing
+«Політика конфіденційності» and «Умови використання».
+
+## Technical approach
+
+Follow the existing legal-page pattern exactly:
+
+- `BaseLayout` + `Header variant="main"` + `Footer variant="legal"`.
+- Tailwind only; `<article class="max-w-4xl mx-auto">`, same section rhythm
+  (`h2.text-2xl font-serif`, `text-navy-700 leading-relaxed space-y-4`, lists, sage-50
+  contact box).
+- Static Astro content — no React, no new dependencies.
+- Requisite values and effective dates marked as explicit placeholders (e.g. `[РНОКПП]`)
+  for the owner to fill in.
+- BaseLayout SEO `title` / `description` per page, in Ukrainian.
+
+## Out of scope (YAGNI)
+
+- Separate cookie policy page.
+- Cookie consent banner / consent tracking.
+- Multilingual legal pages.
+- Any backend logic for the offer.
+- Copying example sites' text.
+
+## Acceptance criteria
+
+- `/oferta` exists with all 15 sections and seller-requisite placeholders.
+- `/privacy-policy` reflects the real stack (WayForPay, Supabase, Resend, Vercel, Telegram)
+  and includes a cookies section.
+- `/terms` is slimmed to site usage + coaching disclaimer + IP, and links purchases to the
+  offer and data to the privacy policy.
+- Footer legal block links to all three pages.
+- All three pages render in Ukrainian, use the shared layout/header/footer, and build
+  cleanly (`npm run build` / `astro check` passes).
+- No example-site text is reproduced.

--- a/docs/superpowers/specs/2026-06-21-opora-payment-result-pages-design.md
+++ b/docs/superpowers/specs/2026-06-21-opora-payment-result-pages-design.md
@@ -1,0 +1,134 @@
+# Opora Payment Result Pages — Design
+
+**Date:** 2026-06-21
+**Status:** Draft (awaiting review)
+**Feature:** Branded success and error pages shown after a WayForPay payment for the "Опора на себе" course.
+
+## Problem
+
+The "Опора" course is sold via a hosted WayForPay payment button
+(`PUBLIC_OPORA_CHECKOUT_URL`). After paying, the buyer currently lands on
+WayForPay's generic, unbranded result page. The course itself is delivered
+through a Telegram bot, and the buyer must open that bot manually to get
+access. Today there is nothing that bridges a paying customer to the bot, so a
+successful payment can dead-end with the customer not knowing where to go.
+
+## Goal
+
+After payment, send the customer to a branded page on zhulova.com that:
+
+- **On success** — confirms the payment and routes the buyer to the Telegram
+  bot to claim the course (the single most important action).
+- **On failure** — calmly explains the payment did not go through and offers a
+  clear retry plus a way to contact us.
+
+## Background: WayForPay button redirects
+
+WayForPay payment buttons support per-button client redirection, configured in
+the merchant cabinet (toggle "Налаштувати переадресацію клієнта"):
+
+- **Approve URL** — page shown after a successful payment.
+- **Decline URL** — page shown after a failed/declined payment.
+
+**Constraint that drives the design:** WayForPay sends a **POST** request to the
+return URL by default. This site is static (Astro SSG on Vercel); a static page
+cannot process a POST. Therefore the button must have the
+**"Вимкнути надсилання POST на returnUrl"** toggle enabled so the redirect is a
+plain **GET** to a static page.
+
+Sources:
+- [Платіжна кнопка — WayForPay help](https://help.wayforpay.com/view/3342550)
+- [Перенаправлення клієнта після оплати — WayForPay help](https://help.wayforpay.com/view/3342451)
+- [Налаштування переадресації в платіжних кнопках — WayForPay blog](https://blog.wayforpay.com/ru/view/nastrojka-pereadresacii-posle-oplaty-v-plateznyh-knopkah-i-otpravka-sobytij-v-sendpulse-obnovlenia-v-wayforpay-id232.html)
+
+## Scope
+
+In scope:
+- New static page `/courses/opora/success`.
+- New static page `/courses/opora/error`.
+- New environment variable `PUBLIC_OPORA_BOT_URL` for the Telegram bot link.
+- E2E coverage for both pages.
+- Step-by-step WayForPay cabinet configuration notes (manual action by the
+  owner, not code).
+
+Out of scope:
+- Any server-side verification of payment (the pages are informational only; we
+  do not validate that a real payment occurred).
+- Webhook / automated bot delivery.
+- A generic, course-agnostic success page (only one course exists today).
+
+## Pages
+
+Both pages use `BaseLayout`, `Header variant="main"`, and
+`Footer variant="legal"`, matching `/courses/opora`. Content is in Ukrainian,
+consistent with the rest of the Opora landing. Both pages set `noindex` so they
+do not appear in search results.
+
+### `/courses/opora/success.astro`
+
+- Positive visual (checkmark).
+- Heading: "Оплата пройшла успішно".
+- Short confirmation line, e.g. "Дякую! Доступ до курсу — у телеграм-боті."
+- **Primary CTA:** "Відкрити бота й забрати курс" → `PUBLIC_OPORA_BOT_URL`,
+  opens in a new tab (reuses the external-link / new-tab behavior already in
+  `CtaButton`).
+- Fallback line: "Бот не відкрився? Напиши нам" → `/contacts`.
+- Fallback behavior when `PUBLIC_OPORA_BOT_URL` is empty: the CTA points to
+  `/contacts` so the page never has a dead button.
+
+### `/courses/opora/error.astro`
+
+- Calm, non-alarming visual.
+- Heading: "Оплата не пройшла".
+- Short text inviting another attempt.
+- **Primary CTA:** "Спробувати ще раз" → `PUBLIC_OPORA_CHECKOUT_URL` (back to
+  the WayForPay button), opens in a new tab for external URL.
+- Secondary link: "Звернутися до нас" → `/contacts`.
+
+## Configuration
+
+New environment variable, following the existing `PUBLIC_OPORA_CHECKOUT_URL`
+pattern:
+
+- `PUBLIC_OPORA_BOT_URL` — Telegram bot link (e.g. `https://t.me/<bot>`).
+- Added to `.env`, `.env.example`, and Vercel (Production + Preview).
+
+WayForPay cabinet (owner action, documented in the plan):
+
+1. Open the payment button settings.
+2. Enable "Налаштувати переадресацію клієнта".
+3. Approve URL: `https://zhulova.com/courses/opora/success`
+4. Decline URL: `https://zhulova.com/courses/opora/error`
+5. Enable "Вимкнути надсилання POST на returnUrl" (forces a GET redirect).
+
+## Routing
+
+Nested under `/courses/opora/` to read as a continuation of the course flow.
+In Astro, the file `src/pages/courses/opora.astro` and the folder
+`src/pages/courses/opora/` coexist without conflict
+(`/courses/opora`, `/courses/opora/success`, `/courses/opora/error`).
+
+## Testing
+
+E2E (`tests/e2e/`), following existing patterns:
+
+- Both pages load successfully (200, correct URL).
+- Each page has a visible `main h1`.
+- Success page: primary CTA links to the bot URL (or `/contacts` fallback) and
+  has `target="_blank"`.
+- Error page: primary CTA links to the checkout URL; secondary link to
+  `/contacts`.
+- Both pages expose `<meta name="robots" content="noindex">`.
+
+## Decisions
+
+- **D1 — Static pages, no payment verification.** The hosted button gives us no
+  trustworthy signed payload on a GET redirect, and the course is delivered by
+  the bot, not by the page. Pages are purely informational; verification would
+  add a serverless route and complexity for no user-facing gain. (YAGNI.)
+- **D2 — Bot link in an env var.** Mirrors `PUBLIC_OPORA_CHECKOUT_URL`; the link
+  can change without code edits or redeploys of logic.
+- **D3 — Course-scoped routes, not generic `/success`.** Only one course exists;
+  nesting under `/courses/opora/` is clearer. Revisit if more courses are added.
+- **D4 — GET redirect required.** The WayForPay "disable POST" toggle is
+  mandatory because the site is static; without it the redirect breaks.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ interface Props {
   description: string;
   image?: string;
   canonical?: string;
+  noindex?: boolean;
 }
 
 const {
@@ -15,6 +16,7 @@ const {
   description,
   image = '/images/og-default.jpg',
   canonical,
+  noindex = false,
 } = Astro.props;
 
 const siteUrl = import.meta.env.PUBLIC_SITE_URL || 'https://zhulova.com';
@@ -33,6 +35,7 @@ const ogImageURL = new URL(image, siteUrl).toString();
     <title>{title}</title>
     <meta name="title" content={title} />
     <meta name="description" content={description} />
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
 
     <!-- Canonical URL -->
     <link rel="canonical" href={canonicalURL} />

--- a/src/pages/courses/opora/error.astro
+++ b/src/pages/courses/opora/error.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Header from '@components/layout/Header.astro';
+import Footer from '@components/layout/Footer.astro';
+import CtaButton from '@components/sections/opora/CtaButton.astro';
+
+// Send the buyer back to the WayForPay button to try again.
+const checkoutUrl: string = import.meta.env.PUBLIC_OPORA_CHECKOUT_URL || '#';
+---
+
+<BaseLayout
+  title="Оплата не пройшла — Опора на себе · Вікторія Жульова"
+  description="Оплата не пройшла. Спробуй ще раз або звернись до нас."
+  noindex
+>
+  <Header variant="main" />
+
+  <main class="min-h-screen bg-white pt-32 pb-20">
+    <section class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h1 class="text-3xl md:text-4xl font-serif font-bold text-navy-900 mb-4">
+        Оплата не пройшла
+      </h1>
+
+      <p class="text-lg text-navy-700 mb-8 leading-relaxed">
+        Щось пішло не так під час оплати, і гроші не списано. Спробуй ще раз — це займе
+        хвилину.
+      </p>
+
+      <CtaButton href={checkoutUrl}>Спробувати ще раз</CtaButton>
+
+      <p class="mt-6 text-sm text-navy-500">
+        Не виходить?
+        <a href="/contacts" class="text-gold-600 underline hover:text-gold-500">Звернись до нас</a>.
+      </p>
+    </section>
+  </main>
+
+  <Footer variant="legal" />
+</BaseLayout>

--- a/src/pages/courses/opora/success.astro
+++ b/src/pages/courses/opora/success.astro
@@ -1,0 +1,54 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Header from '@components/layout/Header.astro';
+import Footer from '@components/layout/Footer.astro';
+import CtaButton from '@components/sections/opora/CtaButton.astro';
+
+// Bot link delivers the course; fall back to contacts if not configured yet.
+const botUrl: string = import.meta.env.PUBLIC_OPORA_BOT_URL || '/contacts';
+---
+
+<BaseLayout
+  title="Оплата успішна — Опора на себе · Вікторія Жульова"
+  description="Оплата пройшла успішно. Відкрий телеграм-бот, щоб забрати курс «Опора на себе»."
+  noindex
+>
+  <Header variant="main" />
+
+  <main class="min-h-screen bg-white pt-32 pb-20">
+    <section class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <div
+        class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gold-100 text-gold-600"
+      >
+        <svg
+          class="h-8 w-8"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+
+      <h1 class="text-3xl md:text-4xl font-serif font-bold text-navy-900 mb-4">
+        Оплата пройшла успішно
+      </h1>
+
+      <p class="text-lg text-navy-700 mb-8 leading-relaxed">
+        Дякую за покупку! Доступ до курсу — у телеграм-боті. Натисни кнопку нижче, щоб
+        відкрити його й почати.
+      </p>
+
+      <CtaButton href={botUrl}>Відкрити бота й забрати курс</CtaButton>
+
+      <p class="mt-6 text-sm text-navy-500">
+        Бот не відкрився?
+        <a href="/contacts" class="text-gold-600 underline hover:text-gold-500">Напиши нам</a>.
+      </p>
+    </section>
+  </main>
+
+  <Footer variant="legal" />
+</BaseLayout>

--- a/tests/e2e/opora-payment-pages.spec.ts
+++ b/tests/e2e/opora-payment-pages.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the Opora payment result pages (success / error).
+ * These pages are where WayForPay redirects the buyer after payment.
+ */
+
+test.describe('Opora Payment Result Pages', () => {
+  test.describe('Success page (/courses/opora/success)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/courses/opora/success', { waitUntil: 'networkidle' });
+    });
+
+    test('should load successfully', async ({ page }) => {
+      await expect(page).toHaveURL(/\/courses\/opora\/success$/);
+    });
+
+    test('should display a heading', async ({ page }) => {
+      const heading = page.locator('main h1').first();
+      await expect(heading).toBeVisible();
+      await expect(heading).toContainText(/успішно/i);
+    });
+
+    test('should have a primary CTA with a non-empty link', async ({ page }) => {
+      const cta = page.locator('main a').filter({ hasText: /забрати курс/i }).first();
+      await expect(cta).toBeVisible();
+      const href = await cta.getAttribute('href');
+      expect(href).toBeTruthy();
+      expect(href!.length).toBeGreaterThan(1);
+    });
+
+    test('should be excluded from search engines (noindex)', async ({ page }) => {
+      const robots = page.locator('meta[name="robots"]');
+      await expect(robots).toHaveAttribute('content', /noindex/);
+    });
+
+    test('should have navigation and footer', async ({ page }) => {
+      await expect(page.getByRole('banner')).toBeVisible();
+      await expect(page.getByRole('contentinfo')).toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/opora-payment-pages.spec.ts
+++ b/tests/e2e/opora-payment-pages.spec.ts
@@ -39,4 +39,36 @@ test.describe('Opora Payment Result Pages', () => {
       await expect(page.getByRole('contentinfo')).toBeVisible();
     });
   });
+
+  test.describe('Error page (/courses/opora/error)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/courses/opora/error', { waitUntil: 'networkidle' });
+    });
+
+    test('should load successfully', async ({ page }) => {
+      await expect(page).toHaveURL(/\/courses\/opora\/error$/);
+    });
+
+    test('should display a heading', async ({ page }) => {
+      const heading = page.locator('main h1').first();
+      await expect(heading).toBeVisible();
+      await expect(heading).toContainText(/не пройшла/i);
+    });
+
+    test('should have a retry CTA with a non-empty link', async ({ page }) => {
+      const cta = page.locator('main a').filter({ hasText: /спробувати ще раз/i }).first();
+      await expect(cta).toBeVisible();
+      const href = await cta.getAttribute('href');
+      expect(href).toBeTruthy();
+    });
+
+    test('should link to contacts', async ({ page }) => {
+      await expect(page.locator('main a[href="/contacts"]').first()).toBeVisible();
+    });
+
+    test('should be excluded from search engines (noindex)', async ({ page }) => {
+      const robots = page.locator('meta[name="robots"]');
+      await expect(robots).toHaveAttribute('content', /noindex/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the two branded pages WayForPay redirects to after a payment for the "Опора на себе" course, plus supporting config.

- **`/courses/opora/success`** — confirms payment and routes the buyer to the Telegram bot to claim the course (link from `PUBLIC_OPORA_BOT_URL`, falls back to `/contacts` when unset).
- **`/courses/opora/error`** — decline page with a retry (back to the WayForPay button via `PUBLIC_OPORA_CHECKOUT_URL`) and a contacts link.
- **`BaseLayout`** gains an optional `noindex` prop (defaults off; both result pages set it so they stay out of search).
- **`PUBLIC_OPORA_BOT_URL`** documented in `.env.example`.

Pages are static and informational only — no server-side payment verification (the course is delivered by the Telegram bot). Buttons reuse the existing `CtaButton` (external links open in a new tab).

## Tests

E2E in `tests/e2e/opora-payment-pages.spec.ts` — 10/10 passing (page load, heading, CTA, `/contacts` link, `noindex` meta for both pages). `astro check`: 0 errors.

## Follow-up (manual, not in this PR)

- Set `PUBLIC_OPORA_BOT_URL` in Vercel (Production + Preview).
- In the WayForPay cabinet, enable client redirection on the button: Approve URL → `/courses/opora/success`, Decline URL → `/courses/opora/error`, and enable "disable POST to returnUrl" so the redirect is a GET (required for static pages).

Spec: `docs/superpowers/specs/2026-06-21-opora-payment-result-pages-design.md`
Plan: `docs/superpowers/plans/2026-06-21-opora-payment-result-pages.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)