### PR TITLE
fix(api): deploy submit-lead as serverless function (Astro 5 prerender)

### DIFF
--- a/src/pages/api/submit-lead.ts
+++ b/src/pages/api/submit-lead.ts
@@ -3,6 +3,11 @@ import { Resend } from 'resend';
 import { z } from 'zod';
 import { logError, logWarn, logInfo } from '@utils/logger';
 
+// Render on-demand as a Vercel serverless function. In Astro 5 static mode
+// endpoints prerender by default, which a POST handler cannot do — without
+// this the route 404s in production.
+export const prerender = false;
+
 // Environment validation flag (for cold start logging)
 let envValidated = false;
 


### PR DESCRIPTION
## Problem

The consultation form on production fails with `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. `POST https://zhulova.com/api/submit-lead` returns **HTTP 404** (the HTML 404 page) instead of JSON, so the client's `response.json()` throws.

## Root cause

The project runs Astro 5 (`output: 'static'`). In Astro 5 static mode, endpoints **prerender by default**. A POST-only handler cannot be prerendered, so `src/pages/api/submit-lead.ts` produced no serverless function and the route 404s in production. (Astro 4 auto-served API routes — hence the now-outdated note in CLAUDE.md. The form broke on the Astro 4 → 5 upgrade.)

CI did not catch this because the e2e tests mock the endpoint with `page.route()`.

## Fix

Add `export const prerender = false;` to the endpoint so the Vercel adapter bundles it as an on-demand function.

## Verification (production build)

```
[@astrojs/vercel] Bundling function ... entry.mjs
.vercel/output/functions/_render.func        # function emitted
.vercel/output/config.json → "^/api/submit-lead/?$"   # route mapped
# no .vercel/output/static/api/ → not prerendered
```

`astro check` + build: 0 errors.

## Follow-up (not in this PR)

- CI does not exercise the real function (e2e mocks it). Consider a build-output assertion or a `vercel build` smoke check so this regression class is caught automatically.
- Update CLAUDE.md's claim that API routes auto-convert without `prerender = false` (true for Astro 4, not Astro 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)