### PR TITLE
fix(api): make lead DB write non-fatal so the form succeeds

### DIFF
--- a/src/pages/api/submit-lead.ts
+++ b/src/pages/api/submit-lead.ts
@@ -200,36 +200,45 @@ export const POST: APIRoute = async ({ request }) => {
       referrer: request.headers.get('referer') || null,
     };
 
-    const { data: dbData, error: dbError } = await supabase
-      .from('leads')
-      .insert([leadData])
-      .select('id')
-      .single();
+    // Persist to Supabase. The email notification above already delivered the
+    // lead, so a database failure must NOT fail the user's submission — the DB
+    // is a secondary log (e.g. the project may be paused). Log and continue.
+    let leadId: string | null = null;
+    try {
+      const { data: dbData, error: dbError } = await supabase
+        .from('leads')
+        .insert([leadData])
+        .select('id')
+        .single();
 
-    if (dbError) {
-      // T013: Database error logging
-      logError(`Database insert failed: ${dbError.message}`, {
+      if (dbError) {
+        // T013: Database error logging (non-fatal — email already sent)
+        logError(`Database insert failed (non-fatal): ${dbError.message}`, {
+          action: 'insert_lead',
+          duration: Date.now() - startTime,
+          errorCode: dbError.code || 'DB_ERROR',
+          affectedResource: 'leads',
+          httpStatus: 200,
+        }, endpoint);
+      } else {
+        leadId = dbData.id;
+      }
+    } catch (dbException) {
+      const message = dbException instanceof Error ? dbException.message : 'Unknown DB error';
+      logError(`Database insert threw (non-fatal): ${message}`, {
         action: 'insert_lead',
         duration: Date.now() - startTime,
-        errorCode: dbError.code || 'DB_ERROR',
+        errorCode: 'DB_EXCEPTION',
         affectedResource: 'leads',
-        httpStatus: 500,
+        httpStatus: 200,
       }, endpoint);
-
-      return new Response(
-        JSON.stringify({
-          success: false,
-          error: 'Failed to save lead to database',
-        }),
-        { status: 500, headers: { 'Content-Type': 'application/json' } }
-      );
     }
 
     return new Response(
       JSON.stringify({
         success: true,
         message: 'Thank you! Your message has been sent.',
-        leadId: dbData.id,
+        leadId,
         emailId: data?.id
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }


### PR DESCRIPTION
## Problem

After fixing the 404 (PR #52), the consultation form returns `{"success":false,"error":"Failed to save lead to database"}`. Root cause: the **Supabase project is paused** (free tier, >90 days, no longer restorable via dashboard), so every insert into `leads` fails.

The email notification is sent *before* the DB write, so the owner already receives every lead by email — only the DB log and the user-facing success were broken.

## Fix

Treat the Supabase write as a secondary log, not the critical path:
- Wrap the insert in try/catch (a paused project can throw, not just return an error).
- On DB failure, log it (non-fatal) and continue.
- Return `success: true` once the email is delivered; `leadId` is `null` when the DB write did not complete.

This makes the form work immediately for users while the database is down. No env or schema change required — when a fresh Supabase project is connected later, inserts resume automatically.

## Verification

`astro check`: 0 errors. Behavior: with the DB unreachable, the handler now returns 200 + `success: true` after the email send (previously 500).

## Follow-up

Stand up a new Supabase project and update `SUPABASE_URL` / `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_KEY` in Vercel to restore lead logging (the old project's data is downloadable as a backup but the instance is unrecoverable via dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)