### PR TITLE
feat(api): notify multiple recipients on consultation form

### DIFF
--- a/src/pages/api/submit-lead.ts
+++ b/src/pages/api/submit-lead.ts
@@ -124,7 +124,8 @@ export const POST: APIRoute = async ({ request }) => {
     // Send email notification via Resend
     const { data, error } = await resend.emails.send({
       from: fromEmail,
-      to: notificationEmail,
+      // NOTIFICATION_EMAIL may hold several comma-separated recipients
+      to: notificationEmail.split(',').map((e: string) => e.trim()).filter(Boolean),
       replyTo: validatedData.email || undefined,
       subject: `New Consultation Request from ${validatedData.name}`,
       html: `


### PR DESCRIPTION
## Summary

The consultation form notification went to a single inbox. Parse `NOTIFICATION_EMAIL` as a comma-separated list and pass every address to Resend's `to` field, so multiple people are notified.

`NOTIFICATION_EMAIL` is set in Vercel (Production/Preview/Development) to `goshazvir@gmail.com,office.osypenko@gmail.com`.

## Verification

`astro check`: 0 errors. After deploy, a form submission emails both recipients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)